### PR TITLE
fix: skills subcommand typo in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Official skill registry for [ZeroClaw](https://www.zeroclawlabs.ai) — communit
 ## Install a skill
 
 ```bash
-zeroclaw skill install <skill-name>
+zeroclaw skills install <skill-name>
 ```
 
 ## Browse skills
@@ -108,7 +108,7 @@ You are a [role]. When given a task:
 Documentation for users browsing the registry. Include:
 
 - What the skill does
-- Install command (`zeroclaw skill install my-skill`)
+- Install command (`zeroclaw skills install my-skill`)
 - What permissions it needs and why
 - Example usage
 

--- a/skills/api-tester/README.md
+++ b/skills/api-tester/README.md
@@ -1,5 +1,5 @@
 # api-tester
 
 ```bash
-zeroclaw skill install api-tester
+zeroclaw skills install api-tester
 ```

--- a/skills/auto-coder/README.md
+++ b/skills/auto-coder/README.md
@@ -10,7 +10,7 @@ Autonomous code generation agent for ZeroClaw.
 
 ## Install
 ```bash
-zeroclaw skill install auto-coder
+zeroclaw skills install auto-coder
 ```
 
 ## Permissions

--- a/skills/ci-helper/README.md
+++ b/skills/ci-helper/README.md
@@ -1,5 +1,5 @@
 # ci-helper
 
 ```bash
-zeroclaw skill install ci-helper
+zeroclaw skills install ci-helper
 ```

--- a/skills/code-reviewer/README.md
+++ b/skills/code-reviewer/README.md
@@ -1,5 +1,5 @@
 # code-reviewer
 
 ```bash
-zeroclaw skill install code-reviewer
+zeroclaw skills install code-reviewer
 ```

--- a/skills/data-analyst/README.md
+++ b/skills/data-analyst/README.md
@@ -1,5 +1,5 @@
 # data-analyst
 
 ```bash
-zeroclaw skill install data-analyst
+zeroclaw skills install data-analyst
 ```

--- a/skills/discord-moderator/README.md
+++ b/skills/discord-moderator/README.md
@@ -1,5 +1,5 @@
 # discord-moderator
 
 ```bash
-zeroclaw skill install discord-moderator
+zeroclaw skills install discord-moderator
 ```

--- a/skills/doc-writer/README.md
+++ b/skills/doc-writer/README.md
@@ -1,5 +1,5 @@
 # doc-writer
 
 ```bash
-zeroclaw skill install doc-writer
+zeroclaw skills install doc-writer
 ```

--- a/skills/email-responder/README.md
+++ b/skills/email-responder/README.md
@@ -1,5 +1,5 @@
 # email-responder
 
 ```bash
-zeroclaw skill install email-responder
+zeroclaw skills install email-responder
 ```

--- a/skills/git-assistant/README.md
+++ b/skills/git-assistant/README.md
@@ -1,5 +1,5 @@
 # git-assistant
 
 ```bash
-zeroclaw skill install git-assistant
+zeroclaw skills install git-assistant
 ```

--- a/skills/knowledge-base/README.md
+++ b/skills/knowledge-base/README.md
@@ -1,5 +1,5 @@
 # knowledge-base
 
 ```bash
-zeroclaw skill install knowledge-base
+zeroclaw skills install knowledge-base
 ```

--- a/skills/multi-agent-router/README.md
+++ b/skills/multi-agent-router/README.md
@@ -1,5 +1,5 @@
 # multi-agent-router
 
 ```bash
-zeroclaw skill install multi-agent-router
+zeroclaw skills install multi-agent-router
 ```

--- a/skills/security-scanner/README.md
+++ b/skills/security-scanner/README.md
@@ -1,5 +1,5 @@
 # security-scanner
 
 ```bash
-zeroclaw skill install security-scanner
+zeroclaw skills install security-scanner
 ```

--- a/skills/self-improving-agent/README.md
+++ b/skills/self-improving-agent/README.md
@@ -1,5 +1,5 @@
 # self-improving-agent
 
 ```bash
-zeroclaw skill install self-improving-agent
+zeroclaw skills install self-improving-agent
 ```

--- a/skills/slack-connector/README.md
+++ b/skills/slack-connector/README.md
@@ -1,5 +1,5 @@
 # slack-connector
 
 ```bash
-zeroclaw skill install slack-connector
+zeroclaw skills install slack-connector
 ```

--- a/skills/telegram-assistant/README.md
+++ b/skills/telegram-assistant/README.md
@@ -4,5 +4,5 @@ Full-featured Telegram bot skill for ZeroClaw.
 
 ## Install
 ```bash
-zeroclaw skill install telegram-assistant
+zeroclaw skills install telegram-assistant
 ```

--- a/skills/web-researcher/README.md
+++ b/skills/web-researcher/README.md
@@ -4,5 +4,5 @@ Deep web research with source citation for ZeroClaw.
 
 ## Install
 ```bash
-zeroclaw skill install web-researcher
+zeroclaw skills install web-researcher
 ```


### PR DESCRIPTION
Fixes: https://github.com/zeroclaw-labs/zeroclaw/issues/5683

Correct command:
`zeroclaw skills install <skill-name>`

What is there in the docs:
`zeroclaw skill install <skill-name>`

Proof:
<img width="918" height="608" alt="image" src="https://github.com/user-attachments/assets/3bed6e11-2e1e-40c3-9a56-808003d7bdf6" />
