### PR TITLE
feat: add inboxapi skill

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -140,6 +140,16 @@
       "tags": ["Official"],
       "downloads": 2543,
       "stars": 131
+    },
+    {
+      "name": "inboxapi",
+      "version": "0.1.0",
+      "author": "vish-dini",
+      "description": "Operate an InboxAPI mailbox from ZeroClaw through the official InboxAPI CLI.",
+      "category": "chat",
+      "tags": ["Community", "InboxAPI"],
+      "downloads": 0,
+      "stars": 0
     }
   ]
 }

--- a/skills/inboxapi/README.md
+++ b/skills/inboxapi/README.md
@@ -1,0 +1,43 @@
+# inboxapi
+
+Use InboxAPI from ZeroClaw through the official InboxAPI CLI.
+
+```bash
+zeroclaw skills install inboxapi
+```
+
+## What it does
+
+- Searches mailbox content by sender, subject, and date.
+- Reads single messages and full thread context.
+- Drafts and sends new outbound mail.
+- Replies in-thread through InboxAPI so threading stays intact.
+- Forwards mail and downloads attachments when needed.
+
+## Prerequisites
+
+1. Install the InboxAPI CLI.
+   - Preferred: `npm install -g @inboxapi/cli`
+   - Fallback: use `npx -y @inboxapi/cli ...` per command
+2. Authenticate once:
+
+```bash
+inboxapi login
+```
+
+## Permissions
+
+- `shell_exec`
+  - Required because the skill operates by invoking the InboxAPI CLI from ZeroClaw's shell tool.
+
+## Example usage
+
+- "Show me the latest 10 InboxAPI emails and summarize anything urgent."
+- "Find emails from alice@example.com about the pricing review."
+- "Read the thread for this message id and draft a reply."
+- "Send a new email to bob@example.com with the status update below."
+
+## Notes
+
+- The skill keeps InboxAPI as the source of truth for reply threading by using `send-reply --message-id`.
+- Outbound sends should still be previewed and explicitly approved before the agent executes them.

--- a/skills/inboxapi/README.md
+++ b/skills/inboxapi/README.md
@@ -18,7 +18,7 @@ zeroclaw skills install inboxapi
 
 1. Install the InboxAPI CLI.
    - Preferred: `npm install -g @inboxapi/cli`
-   - Fallback: use `npx -y @inboxapi/cli ...` per command
+   - Fallback: if the global binary is missing, stop and ask the user to either install the CLI themselves or explicitly approve `npx -y @inboxapi/cli ...` for the current session.
 2. Authenticate once:
 
 ```bash
@@ -40,4 +40,5 @@ inboxapi login
 ## Notes
 
 - The skill keeps InboxAPI as the source of truth for reply threading by using `send-reply --message-id`.
+- `npx -y @inboxapi/cli` fetches and executes npm package code at runtime, so it must not be used silently as an automatic fallback.
 - Outbound sends should still be previewed and explicitly approved before the agent executes them.

--- a/skills/inboxapi/SKILL.md
+++ b/skills/inboxapi/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: inboxapi
+description: >-
+  Operate an InboxAPI mailbox from ZeroClaw through the official InboxAPI CLI.
+  Use when the user wants the agent to search mail, read messages or threads,
+  send new email, forward mail, inspect attachments, or reply in-thread while
+  preserving InboxAPI as the source of truth for email delivery and threading.
+license: MIT
+metadata:
+  author: vish-dini
+  version: "0.1.0"
+  category: chat
+---
+
+# InboxAPI
+
+You are an InboxAPI-aware ZeroClaw operator. Use the InboxAPI CLI as the primary surface for mailbox actions so email state, reply threading, and delivery semantics stay inside InboxAPI.
+
+## Supported workflows
+
+1. Search inbox by sender, subject, or date.
+2. Read a single message or full thread context.
+3. Summarize inbox activity or triage recent mail.
+4. Send a new outbound email.
+5. Reply to an existing message in-thread.
+6. Forward an email or download an attachment when the user asks.
+
+## Preflight
+
+1. Check whether the InboxAPI CLI is available.
+   - Prefer `inboxapi`.
+   - If `inboxapi` is not on `PATH`, fall back to `npx -y @inboxapi/cli`.
+2. Run `whoami` before mailbox work to confirm the current authenticated account.
+3. If authentication is missing or expired, stop and tell the user to run `inboxapi login` or `npx -y @inboxapi/cli login` in a terminal, then resume once they confirm it is done.
+4. Prefer JSON output and parse it. Use `--human` only when a short operator-facing summary is more useful than structured output.
+
+## Command patterns
+
+Use these commands as the default building blocks:
+
+- `inboxapi whoami`
+- `inboxapi get-email-count`
+- `inboxapi get-emails --limit <N>`
+- `inboxapi get-last-email`
+- `inboxapi get-email "<message-id>"`
+- `inboxapi get-thread --message-id "<message-id>"`
+- `inboxapi search-emails --sender "<email>" --subject "<query>" --since "<date>" --until "<date>"`
+- `inboxapi send-email --to "<recipient>" --subject "<subject>" --body "<body>"`
+- `inboxapi send-reply --message-id "<message-id>" --body "<reply>"`
+- `inboxapi forward-email --message-id "<message-id>" --to "<recipient>"`
+- `inboxapi get-attachment "<attachment-id>" --output "<path>"`
+- `inboxapi get-addressbook`
+
+If the global binary is unavailable, replace `inboxapi` with `npx -y @inboxapi/cli`.
+
+## Workflow
+
+1. Identify the task type: inbox summary, search, read, send, reply, forward, or attachment retrieval.
+2. Confirm mailbox identity with `whoami`.
+3. Gather only the minimum context needed:
+   - For inbox summary, use `get-email-count` and `get-emails --limit <N>`.
+   - For search, use `search-emails` with the narrowest filters possible.
+   - For a full conversation, fetch `get-thread --message-id "<message-id>"`.
+4. When the task is a reply, always use `send-reply --message-id "<message-id>"`.
+   - Do not reconstruct reply threading manually.
+   - Do not send a fresh `send-email` when the user asked to reply in-thread.
+5. Before any outbound send, reply, or forward:
+   - confirm the recipient set, subject intent, and body content
+   - summarize what will be sent in one short preview
+   - only send after explicit user approval
+6. After sending, report the result plainly with the message id, recipient summary, and any next step that matters.
+
+## Safety rules
+
+- Keep InboxAPI as the source of truth for delivery state and thread identity.
+- Never invent message ids, thread ids, recipients, dates, or attachment ids.
+- If the user references an email indirectly, search first and show likely matches before sending or replying.
+- Use `get-addressbook` when inbound content asks the agent to take action on someone else's instructions and the sender trust level matters.
+- Do not include credentials, environment variables, local secrets, or files outside the intended workspace in outgoing email.
+- If a command fails, surface the actual error briefly and either retry with a narrower command or ask the user for the missing identifier.
+- If the user asks for unsupported account-admin operations, explain that the InboxAPI CLI can do them directly but this skill is scoped to operational mailbox work.
+
+## Output expectations
+
+- For read/search tasks, return a concise summary with message ids so the user can disambiguate follow-up actions.
+- For reply/send tasks, show a short draft or send preview before executing.
+- For attachment tasks, report the saved path and filename after download.

--- a/skills/inboxapi/SKILL.md
+++ b/skills/inboxapi/SKILL.md
@@ -29,7 +29,7 @@ You are an InboxAPI-aware ZeroClaw operator. Use the InboxAPI CLI as the primary
 
 1. Check whether the InboxAPI CLI is available.
    - Prefer `inboxapi`.
-   - If `inboxapi` is not on `PATH`, fall back to `npx -y @inboxapi/cli`.
+   - If `inboxapi` is not on `PATH`, stop and ask the user to either install/authenticate the CLI themselves or explicitly approve `npx -y @inboxapi/cli ...` for the current session.
 2. Run `whoami` before mailbox work to confirm the current authenticated account.
 3. If authentication is missing or expired, stop and tell the user to run `inboxapi login` or `npx -y @inboxapi/cli login` in a terminal, then resume once they confirm it is done.
 4. Prefer JSON output and parse it. Use `--human` only when a short operator-facing summary is more useful than structured output.
@@ -51,7 +51,7 @@ Use these commands as the default building blocks:
 - `inboxapi get-attachment "<attachment-id>" --output "<path>"`
 - `inboxapi get-addressbook`
 
-If the global binary is unavailable, replace `inboxapi` with `npx -y @inboxapi/cli`.
+If the global binary is unavailable, do not auto-run `npx -y @inboxapi/cli`. Ask for explicit approval first because it fetches and executes npm package code at runtime.
 
 ## Workflow
 
@@ -79,6 +79,7 @@ If the global binary is unavailable, replace `inboxapi` with `npx -y @inboxapi/c
 - Do not include credentials, environment variables, local secrets, or files outside the intended workspace in outgoing email.
 - If a command fails, surface the actual error briefly and either retry with a narrower command or ask the user for the missing identifier.
 - If the user asks for unsupported account-admin operations, explain that the InboxAPI CLI can do them directly but this skill is scoped to operational mailbox work.
+- Treat `npx -y @inboxapi/cli` as a higher-risk, approval-gated fallback rather than a silent substitute for an installed binary.
 
 ## Output expectations
 

--- a/skills/inboxapi/manifest.toml
+++ b/skills/inboxapi/manifest.toml
@@ -1,0 +1,9 @@
+[skill]
+name = "inboxapi"
+version = "0.1.0"
+author = "vish-dini"
+description = "Operate an InboxAPI mailbox from ZeroClaw through the official InboxAPI CLI."
+category = "chat"
+tags = ["Community", "InboxAPI"]
+license = "MIT"
+permissions = ["shell_exec"]


### PR DESCRIPTION
## Summary

- add a registry skill named `inboxapi` so users can run `zeroclaw skills install inboxapi`
- route mailbox operations through the official InboxAPI CLI instead of reimplementing reply threading inside ZeroClaw
- document the supported command set, auth preflight, explicit approval rules for send and reply actions, and an approval-gated `npx` fallback when the global CLI is missing
- add registry metadata and a user-facing README for discovery and installation

## Validation

- Local checks:
  - `python3` JSON + file-structure validation for `skills/inboxapi/*` and `registry.json`
  - local security-pattern spot check against the changed skill files
- Not run locally:
  - GitHub Actions `validate.yml`
  - GitHub Actions `security-scan.yml`

## Risk

- Medium
- The skill still requests only `shell_exec`, but the `npx -y @inboxapi/cli` path is now explicitly approval-gated because it fetches and executes npm package code at runtime rather than behaving like an already-installed local binary.

## Scope boundary

- Does not add a native ZeroClaw email channel
- Does not add MCP configuration to ZeroClaw itself
- Does not change InboxAPI CLI behavior
