### PR TITLE
fix: harmonize manifest.toml descriptions with SKILL.md frontmatter

### DIFF
--- a/skills/auto-coder/manifest.toml
+++ b/skills/auto-coder/manifest.toml
@@ -2,7 +2,7 @@
 name = "auto-coder"
 version = "0.3.0"
 author = "zeroclaw-labs"
-description = "Autonomous code generation agent. Reads context, writes code, runs tests."
+description = "Autonomous code generation agent. Reads context, writes code, runs tests. Takes a task description and produces working, production-quality code changes. Use when the user wants to implement features, write code, or make code changes autonomously."
 category = "coding"
 tags = ["Official", "Featured"]
 license = "MIT"

--- a/skills/ci-helper/manifest.toml
+++ b/skills/ci-helper/manifest.toml
@@ -2,7 +2,7 @@
 name = "ci-helper"
 version = "0.1.0"
 author = "community"
-description = "Monitor CI/CD pipelines, diagnose failures, suggest fixes."
+description = "Monitor CI/CD pipelines, diagnose failures, suggest fixes. Analyzes build logs to identify root causes, classifies failure types, and recommends specific fixes. Use when a pipeline fails, builds are slow, or the user needs CI/CD troubleshooting."
 category = "devops"
 tags = ["Community"]
 license = "MIT"

--- a/skills/doc-writer/manifest.toml
+++ b/skills/doc-writer/manifest.toml
@@ -2,7 +2,7 @@
 name = "doc-writer"
 version = "0.2.0"
 author = "zeroclaw-labs"
-description = "Generate documentation from code. Supports Markdown, RST, and JSDoc."
+description = "Generate documentation from code. Supports Markdown, RST, and JSDoc. Reads source code and produces clear, accurate, maintainable documentation in the format appropriate to the project. Use when the user wants documentation, docstrings, README files, or API references generated from code."
 category = "writing"
 tags = ["Official"]
 license = "MIT"

--- a/skills/knowledge-base/manifest.toml
+++ b/skills/knowledge-base/manifest.toml
@@ -2,7 +2,7 @@
 name = "knowledge-base"
 version = "0.3.0"
 author = "zeroclaw-labs"
-description = "Build and query a private RAG knowledge base from your documents."
+description = "Build and query a private RAG knowledge base from your documents. Ingests documents, indexes them with embeddings, and answers questions grounded in retrieved context with citations. Use when the user wants to search their own documents, build a knowledge base, or get answers from private content."
 category = "research"
 tags = ["Official", "Featured"]
 license = "MIT"

--- a/skills/security-scanner/manifest.toml
+++ b/skills/security-scanner/manifest.toml
@@ -2,7 +2,7 @@
 name = "security-scanner"
 version = "0.1.1"
 author = "community"
-description = "Scan repos for vulnerabilities, secrets, and dependency issues."
+description = "Scan repos for vulnerabilities, secrets, and dependency issues. Analyzes repositories for exposed credentials, known CVEs, OWASP Top 10 code vulnerabilities, and security misconfigurations. Use when the user wants a security audit, secret scanning, or dependency vulnerability check."
 category = "security"
 tags = ["Community"]
 license = "MIT"

--- a/skills/web-researcher/manifest.toml
+++ b/skills/web-researcher/manifest.toml
@@ -2,7 +2,7 @@
 name = "web-researcher"
 version = "0.2.1"
 author = "zeroclaw-labs"
-description = "Deep web research with source citation. Summarizes findings privately."
+description = "Deep web research with source citation. Summarizes findings privately. Finds, evaluates, and synthesizes information from the web, delivering accurate, well-sourced answers. Use when the user wants to research a topic, find information online, or compare technologies."
 category = "research"
 tags = ["Official"]
 license = "MIT"


### PR DESCRIPTION
## Summary

Six skills (`auto-coder`, `ci-helper`, `doc-writer`, `knowledge-base`, `security-scanner`, `web-researcher`) carry richer `description` text in their `SKILL.md` YAML frontmatter than in `manifest.toml`. The ZeroClaw runtime detects this drift at load time and emits a `WARN`:

```
skill 'ci-helper': description mismatch between TOML and SKILL.md — TOML takes precedence
```

The runtime then uses the **TOML** description, so the agent's tool-selection layer sees the shorter, less-useful version. The `SKILL.md` text was clearly authored more carefully — it includes "when to use" guidance the model benefits from.

This PR brings each `manifest.toml` description in line with its `SKILL.md` frontmatter (collapsed to a single line, since TOML lacks YAML's `>-` block-folding). Nothing else changes.

## What changes for users

- Six runtime warnings disappear at skill load.
- The agent receives the longer, when-to-use-aware descriptions for these six skills.

## Test plan

Tested locally on all six skills:

- [x] Edit each `manifest.toml` in the registry clone
- [x] `zeroclaw skills remove <name>` then `zeroclaw skills install <local-path>`
- [x] `zeroclaw skills list 2>&1 | grep "description mismatch"` returns nothing
- [x] `zeroclaw skills audit <name>` passes for all six

Before this PR:

```
WARN skill 'doc-writer': description mismatch between TOML and SKILL.md — TOML takes precedence
WARN skill 'knowledge-base': description mismatch between TOML and SKILL.md — TOML takes precedence
WARN skill 'auto-coder': description mismatch between TOML and SKILL.md — TOML takes precedence
WARN skill 'ci-helper': description mismatch between TOML and SKILL.md — TOML takes precedence
WARN skill 'security-scanner': description mismatch between TOML and SKILL.md — TOML takes precedence
WARN skill 'web-researcher': description mismatch between TOML and SKILL.md — TOML takes precedence
```

After this PR: zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)