### PR TITLE
docs: honest framing for registry trust tiers and audit scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
-# ZeroClaw Skills
+# ZeroClaw Skills Index
 
-Official skill registry for [ZeroClaw](https://www.zeroclawlabs.ai) — community-contributed AI agent skills, tools, and workflows. Skills follow the [agentskills.io](https://agentskills.io/specification) open specification.
+A skill registry for [ZeroClaw](https://www.zeroclawlabs.ai) — AI agent skills, tools, and workflows. Skills follow the [agentskills.io](https://agentskills.io/specification) open specification.
+
+## What we audit, what we don't
+
+This registry is **not a vetted security boundary**. CI runs structure validation and pattern-matching scans (secret detection, dangerous-shape regexes, file-policy checks) on every PR. We do **not** audit skill code for security or correctness, and pattern matching does not catch novel or obfuscated misuse. Runtime behavior — network calls, package installs, files written, commands run — is the user's responsibility to evaluate before installing.
+
+Run `zeroclaw skills audit <name>` and read the skill's `SKILL.md` and `manifest.toml` before installing anything you don't recognize.
+
+## Trust tiers
+
+The `tags` field in `registry.json` carries the trust signal:
+
+- **`Official`** — authored and maintained by `zeroclaw-labs`. Same contribution rules as everything else, but the author is us.
+- **`Community`** — submissions from external contributors. The registry lists them and CI checks structure; we make **no representation** about the author's identity, intent, or the skill's runtime behavior. Treat them as you would any third-party code.
 
 ## Install a skill
 
@@ -16,7 +29,7 @@ Visit the [Skills Hub](https://www.zeroclawlabs.ai/skills) to search and discove
 
 ## Contributing a skill
 
-Anyone can publish a skill. Fork this repo, add your skill, and open a pull request. Two automated CI checks (structure validation + security scanning) must pass before a maintainer reviews.
+Anyone can publish a skill. Fork this repo, add your skill, and open a pull request. Two automated CI checks (structure validation + pattern-matching scans) must pass before a maintainer reviews. Passing CI is a baseline filter, not an endorsement of the skill's runtime behavior — see [What we audit, what we don't](#what-we-audit-what-we-dont).
 
 ### Step 1 — Fork & clone
 


### PR DESCRIPTION
## Summary

The README opened with \"Official skill registry... community-contributed\" and described CI as \"security scanning,\" both of which over-implied that zeroclaw-labs vets the skills it lists. The registry data already carries `Official` vs `Community` tags — the prose was collapsing that distinction. When a community-tagged skill is later compromised, the implicit endorsement leaves the maintainers exposed.

This PR re-frames the README without changing CI logic, `registry.json` shape, or the contribution flow:

- Drops \"Official\" from the H1 and lead paragraph.
- Adds a **\"What we audit, what we don't\"** section in the first ~200 words: structure validation + pattern-matching scans run in CI; no code audit; runtime behavior is the user's responsibility; recommends `zeroclaw skills audit <name>` before installing.
- Adds a **\"Trust tiers\"** section that explicitly names what `Official` and `Community` tags mean.
- Softens the contribution intro from \"structure validation + security scanning\" to \"structure validation + pattern-matching scans\" with a one-line note that passing CI is a baseline filter, not an endorsement, linking to the audit-scope section.
- The existing \"Security scan (`security-scan.yml`)\" subsection is left intact — pattern-matching scans are real and worth listing; the framing problem was treating them as a trust boundary, not the scans themselves.

## Header alternatives

Per the request, two header candidates were on the table:

1. **`# ZeroClaw Skills Index`** *(used in this diff)*
2. `# ZeroClaw Skills Registry — Community Submissions Welcome`

I went with **#1 (`ZeroClaw Skills Index`)** because:
- It's neutral and short — \"Index\" reads as a list/catalog without implying curation.
- #2 is honest but front-loads the marketing tone (\"Community Submissions Welcome\") in a doc whose purpose is to dial back implicit endorsement, and it's noticeably longer than the existing one-line H1 the repo has used.
- The trust-tier and audit-scope sections do the work of communicating openness; the H1 doesn't need to.

Happy to swap to #2 (or a third option) if maintainers prefer — it's a one-line edit.

## What didn't change

- `registry.json` — untouched. JSON-validated locally.
- `.github/workflows/` — no CI logic changes.
- The contribution flow (Steps 1–7) and the `Security scan (security-scan.yml)` subsection — unchanged.
- No emojis added; tone matches the existing matter-of-fact prose.

## Test plan

- [ ] README renders correctly on github.com (visual check on the PR's Files tab and on the branch landing page).
- [ ] No broken links — the new in-page anchor `#what-we-audit-what-we-dont` resolves, and existing external links (zeroclawlabs.ai, agentskills.io) are unchanged.
- [ ] Trust framing reads cleanly within 30 seconds: a new visitor should come away knowing (a) the registry is not a vetted security boundary, (b) `Official` vs `Community` is a trust signal, (c) to run `zeroclaw skills audit` before installing.
- [ ] CI green: validate.yml + security-scan.yml still pass against the docs-only diff.