### PR TITLE
docs: add section for reporting malicious or compromised skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,35 @@ Both checks must pass. If a check fails, a comment will explain what went wrong.
 
 ---
 
+## Reporting a malicious or compromised skill
+
+This is a removal and advisory process, not a vetting process. Skills are scanned at PR time but not continuously audited. If a published skill is acting maliciously — for example, exfiltrating data, executing unexpected shell commands, or fetching and running remote code at runtime — please report it.
+
+### How to report
+
+Open a GitHub Issue in this repo with a title prefixed `[security]` followed by the skill name, e.g. `[security] my-skill`. Include the skill version, what you observed, and any logs or reproduction steps you can share.
+
+### What we'll do
+
+- Triage within 48 hours of the report being filed.
+- On confirmation, remove the skill from `registry.json` immediately.
+- Move the skill directory to `archive/<name>-<sha>/`, where `<sha>` is the commit being archived.
+- File a security advisory via this repo's Security tab.
+
+### What we won't do
+
+- Conduct forensic analysis of compromised contributor accounts.
+- Contact upstream services (package registries, hosting providers, etc.) on a user's behalf.
+- Guarantee a response time outside the stated 48-hour triage window.
+
+### What users can do
+
+- Pin skill versions when installing: `zeroclaw skills install <name>@<version>`.
+- Run `zeroclaw skills audit` before installing a new skill.
+- Watch this repo's Security tab for advisories.
+
+---
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary

Adds a "Reporting a malicious or compromised skill" section to the README, placed after the "What happens when you open a PR" / Security scan section and before the License section. The new section documents how to report (a `[security]`-prefixed GitHub Issue), what maintainers will do on confirmation (remove from `registry.json`, move to `archive/<name>-<sha>/`, file a Security tab advisory), what is explicitly out of scope (forensics on contributor accounts, upstream outreach, SLAs beyond the triage window), and what users can do to reduce exposure (version pinning, `zeroclaw skills audit`, watching the Security tab). Tone matches the existing matter-of-fact CI section; no other text was changed.

## Notes for the maintainer

- The 48-hour triage window is a recommendation — please confirm or adjust before merging.
- If you'd prefer a private email contact (e.g. `security@…`) over GitHub Issues for reports, let me know and I'll swap it in.

## Test plan

- [ ] README renders correctly on github.com (headings, code spans, em-dashes display as expected).
- [ ] The new section is discoverable in the natural top-to-bottom reading flow of the README, between the security scan section and the license footer.
- [ ] `git diff master...pr/security-reporting-sla -- README.md` shows only additions; no other text changed.
- [ ] `python3 -c "import json; json.load(open('registry.json'))"` still passes (registry untouched).