### PR TITLE
docs: document `community` placeholder author convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ permissions = ["file_read"]
 
 **Required fields:** `name`, `version`, `author`, `description`, `category`, `license`
 
+> **About `author = "community"`:** A handful of legacy entries in `registry.json` carry `"community"` as the author. These are placeholder values for skills whose original contributor couldn't be resolved from git history, and they are being phased out as new community-authored skills replace them. New contributions must use a real GitHub login — the placeholder is not accepted for new submissions.
+
 #### Categories
 
 | Category | Description |


### PR DESCRIPTION
## Summary

Originally scoped to resolve every `author: "community"` entry in `registry.json` to a real GitHub login. After mining git history, all 7 community-tagged skills turned out to have been added in the initial seed commit (`74c9c52`) with no upstream PR or noreply-email signal — the original contributors aren't recoverable from this repo's history.

Repurposing the PR to document the placeholder honestly: `"community"` is a deliberate transitional value for entries whose origin can't be verified, and it's being phased out as real community-authored skills replace them. New contributions must use a real GitHub login.

## Changes

- `README.md`: short blockquote note in the Step 3 (`manifest.toml`) section, right under the required-fields line, explaining what `author = "community"` means and that it's not accepted on new submissions.

No data changes; the 7 existing `"community"` entries in `registry.json` are left in place to be phased out organically.

## Why this framing

The placeholder isn't going to disappear in one shot — the user has indicated existing entries will be replaced over time as actual community skills land. Until then, a contributor reading the README and seeing `"community"` in the registry deserves an honest one-line explanation of what they're looking at.

## Test plan

- [ ] README renders cleanly on github.com (blockquote + table flow)
- [ ] `registry.json` still parses (verified locally: `python3 -c "import json; json.load(open('registry.json'))"` — OK)
- [ ] No CI workflow changes
- [ ] Diff is +2 / -0, README only

## Notes for the maintainer

- If you have an external mapping (intake spreadsheet, original source repos, Discord) for any of the 7 placeholder entries — `discord-moderator`, `data-analyst`, `security-scanner`, `api-tester`, `ci-helper`, `email-responder`, `self-improving-agent` — backfilling them is a one-line edit per skill in both `registry.json` and `skills/<name>/manifest.toml`. Happy to do that as a follow-up.