### PR TITLE
feat: add zeroclaw simplify review skill

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -52,6 +52,16 @@
       "stars": 119
     },
     {
+      "name": "zeroclaw-simplify-review",
+      "version": "0.1.0",
+      "author": "zeroclaw-labs",
+      "description": "ZeroClaw-specific simplify preflight. Checks reuse, known project pitfalls, and avoidable complexity before commit or maintainer review.",
+      "category": "coding",
+      "tags": ["Official"],
+      "downloads": 0,
+      "stars": 0
+    },
+    {
       "name": "data-analyst",
       "version": "0.1.0",
       "author": "community",

--- a/skills/zeroclaw-simplify-review/README.md
+++ b/skills/zeroclaw-simplify-review/README.md
@@ -1,0 +1,17 @@
+# zeroclaw-simplify-review
+
+ZeroClaw-specific simplify preflight for changes that are about to be committed, opened as a PR, or reviewed by maintainers. This is not a general replacement for `code-reviewer`; it is a narrower workflow for checking ZeroClaw architecture fit, known project pitfalls, and avoidable complexity.
+
+```bash
+zeroclaw skills install zeroclaw-simplify-review
+```
+
+## Permissions
+
+- `file_read`: reads repository instructions, changed files, nearby source code, and tests so the review can be grounded in the actual ZeroClaw tree.
+
+The skill is read-only by default. It does not require network access, shell execution, or file writes.
+
+## Example usage
+
+Ask an agent to run `zeroclaw-simplify-review` before opening a ZeroClaw PR, or on a PR diff that needs a focused reuse, project-fit, and simplicity pass before the normal review flow.

--- a/skills/zeroclaw-simplify-review/SKILL.md
+++ b/skills/zeroclaw-simplify-review/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: zeroclaw-simplify-review
+description: >-
+  ZeroClaw-specific simplify preflight. Checks reuse, known project pitfalls, and avoidable complexity before commit or maintainer review.
+license: MIT
+metadata:
+  author: zeroclaw-labs
+  version: "0.1.0"
+  category: coding
+---
+
+# ZeroClaw Simplify Review
+
+Use this skill as a ZeroClaw-specific simplify preflight. It is not a replacement for a general code review skill. Use it before commit, before PR creation, during maintainer review, or when the user asks whether a ZeroClaw change can be simpler, better aligned with existing architecture, or safer against known project pitfalls.
+
+For broad, repository-agnostic code review, use a general code review skill. This skill answers narrower ZeroClaw questions:
+
+- Is the patch using existing ZeroClaw traits, helpers, factories, and crate boundaries?
+- Is it avoiding known ZeroClaw failure modes?
+- Is the implementation no more complex than the problem requires?
+- Is it ready to enter the normal PR/review flow with less review churn?
+
+The default mode is read-only. Do not edit files, post comments, add labels, submit reviews, or otherwise mutate project state unless the user explicitly asks for that action and confirms the specific scope.
+
+## Start
+
+Identify the review target from the user's request, supplied diff, PR context, changed-file list, or specific file paths. Then read the ZeroClaw project instructions that are present in the working tree, especially:
+
+1. `AGENTS.md`
+2. `CONTRIBUTING.md`
+3. `.github/pull_request_template.md`
+4. `docs/book/src/contributing/pr-review-protocol.md`
+5. `docs/book/src/maintainers/reviewer-playbook.md`
+
+Only load the docs that exist and are relevant to the target. If the target is small, prefer the nearest source files, tests, and trait/factory wiring over broad documentation reads.
+
+## Review Passes
+
+Run these three passes. If the runtime supports parallel subagents and the user has approved delegation, run them in parallel. Otherwise, run the same passes sequentially.
+
+### Reuse and Architecture
+
+Check whether the change duplicates existing behavior, bypasses traits or factory wiring, adds speculative abstractions, misses an existing helper, or violates ZeroClaw's trait-driven architecture and crate stability tiers.
+
+### Correctness and Quality
+
+Check for bugs, edge cases, stale names, call-site mismatches, state divergence, empty-versus-absent value mistakes, persistence round trips, trait default traps, localization requirements, and missing behavior-first tests.
+
+### Efficiency and Simplicity
+
+Check whether the code is unnecessarily complex, allocates or clones more than needed, adds heavy dependencies, expands runtime footprint, hides side effects, or can be made clearer without changing behavior.
+
+## Aggregation
+
+Merge and de-duplicate the pass results. Lead with findings, ordered by severity:
+
+- **Blocker**: likely bug, security issue, data loss, incorrect public claim, or reviewer-blocking problem.
+- **Important**: should be fixed before PR or merge when practical.
+- **Suggestion**: optional simplification or polish.
+
+Each finding should include a file and line reference when possible, the reason it matters, and a concrete fix direction. If no issues are found, say that clearly and list any remaining test or validation gaps.
+
+## Rules
+
+- Read changed files and adjacent code before judging the patch.
+- Prefer existing ZeroClaw patterns over new abstractions.
+- Treat security, privacy, persistence, localization, and public API behavior as higher-risk surfaces.
+- Do not nitpick formatting that the formatter or linter owns.
+- Keep the output concise enough for a contributor or maintainer to act on.

--- a/skills/zeroclaw-simplify-review/manifest.toml
+++ b/skills/zeroclaw-simplify-review/manifest.toml
@@ -1,0 +1,9 @@
+[skill]
+name = "zeroclaw-simplify-review"
+version = "0.1.0"
+author = "zeroclaw-labs"
+description = "ZeroClaw-specific simplify preflight. Checks reuse, known project pitfalls, and avoidable complexity before commit or maintainer review."
+category = "coding"
+tags = ["Official"]
+license = "MIT"
+permissions = ["file_read"]


### PR DESCRIPTION
# Summary

Adds `zeroclaw-simplify-review`, a ZeroClaw-specific simplify preflight skill for checking whether a patch reuses existing ZeroClaw architecture, avoids known project pitfalls, and can be simpler before commit, PR creation, or maintainer review.

# Why this is separate from `code-reviewer`

The existing `code-reviewer` skill is a broad repository-agnostic review workflow. This skill is narrower: it is for ZeroClaw maintainers and contributors who want a project-fit pass before the normal review flow. It points agents at ZeroClaw-specific instructions, PR/review docs, crate boundaries, trait/factory patterns, localization expectations, persistence traps, and other recurring ZeroClaw review risks. Those project-doc references are conditional: the skill tells agents to load only docs that exist and are relevant in the target ZeroClaw working tree.

# Files changed

- `skills/zeroclaw-simplify-review/SKILL.md`: adds the skill instructions.
- `skills/zeroclaw-simplify-review/manifest.toml`: adds registry metadata with `file_read` only.
- `skills/zeroclaw-simplify-review/README.md`: adds the install note, permissions, and example usage required by this registry.
- `registry.json`: adds the skill entry.

# Validation

Local validation was rerun against the committed branch head.

```text
Local checks passed:
- registry JSON parse
- registry/folder sync
- required skill files present and non-empty
- manifest required fields, name, category, SPDX license, and file_read permission
- permission-combination audit
- trailing-whitespace check for new files
- git diff --check
- scanner-sensitive pattern search over the new skill and registry entry

GitHub Actions for PR #12 passed:
- Validate Skills
- Security Scan
```

# Labels, status, and compatibility

The PR is ready for review. Label applied: `enhancement`. The latest refreshed merge state is clean, and required validation checks are passing.

Compatibility: this is an additive registry/docs change only. It does not change runtime behavior, public APIs, or existing skills.

# Risk and security

Risk is low. This adds Markdown/TOML/JSON registry content only. The skill requests `file_read` so the agent can inspect repository instructions, changed files, adjacent source, and tests. It does not request shell execution, network access, or file writes, and its instructions state that the default mode is read-only.

# Rollback

Remove `skills/zeroclaw-simplify-review/` and the matching `registry.json` entry.
