### PR TITLE
Add sql-executor community skill

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -170,6 +170,16 @@
       "tags": ["Community", "X", "Twitter", "MCP"],
       "downloads": 0,
       "stars": 0
+    },
+    {
+      "name": "sql-executor",
+      "version": "0.1.0",
+      "author": "1mpossible-code",
+      "description": "Write and execute PostgreSQL or Supabase SQL queries from natural-language requests.",
+      "category": "data",
+      "tags": ["Community"],
+      "downloads": 0,
+      "stars": 0
     }
   ]
 }

--- a/skills/sql-executor/README.md
+++ b/skills/sql-executor/README.md
@@ -1,0 +1,62 @@
+# sql-executor
+
+Write and execute PostgreSQL or Supabase SQL from natural-language requests.
+
+## Install
+
+```bash
+zeroclaw skills install sql-executor
+```
+
+## What it does
+
+- translates user requests into SQL
+- inspects schema before guessing table or column names
+- executes unconfirmed read queries inside a database-enforced read-only transaction
+- asks for confirmation before writes or schema changes
+- works with PostgreSQL and Supabase Postgres connection strings
+- avoids asking users to paste database credentials into chat
+
+## Permissions
+
+- `shell_exec` — required to run `psql` and optional `supabase` CLI commands
+
+## Requirements
+
+- `psql` available in your `PATH`
+- optional: Supabase CLI if you want `supabase status` for local projects
+- a database connection string stored outside the conversation in one of these env vars:
+  - `DATABASE_URL`
+  - `POSTGRES_URL`
+  - `POSTGRES_URL_NON_POOLING`
+  - `SUPABASE_DB_URL`
+  - `SUPABASE_DATABASE_URL`
+
+Do not paste database URLs or passwords into chat. Set the env var locally or use the host's local secret/config mechanism.
+
+## Example prompts
+
+- `List all public tables in my database`
+- `Show the 20 newest users created this week`
+- `Count orders by status for the last 30 days`
+- `Add a nullable last_seen_at column to profiles`
+- `Delete test users with email ending in example.com`
+
+## Safety model
+
+Read-only queries can be executed without confirmation only inside a database-enforced read-only transaction/session. If a query attempts a write or side effect and fails under that guard, it must be rerouted through the explicit mutation-confirmation flow.
+
+For mutating queries like `insert`, `update`, `delete`, `alter`, `drop`, and `truncate`, the skill should:
+
+1. draft the SQL
+2. explain the impact
+3. ask for confirmation
+4. execute only after approval
+5. verify the result with a follow-up query when useful
+
+For execution, the skill passes generated SQL to `psql` through stdin/heredoc instead of embedding the SQL inside shell-quoted inline command arguments. Unconfirmed reads are wrapped in `BEGIN READ ONLY; ... COMMIT;`.
+
+## Notes for Supabase
+
+Supabase uses PostgreSQL, so the skill executes SQL through `psql` using the project's Postgres connection string after the user stores it outside the conversation.
+For local Supabase projects, run `supabase status` in your own terminal and set one of the supported env vars from that output.

--- a/skills/sql-executor/SKILL.md
+++ b/skills/sql-executor/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: sql-executor
+description: >-
+  Write and execute PostgreSQL or Supabase SQL queries from natural-language
+  requests. Use when the user wants to inspect schema, run read queries,
+  validate data, or safely perform confirmed database changes.
+version: "0.1.0"
+author: 1mpossible-code
+license: MIT
+category: data
+tags:
+  - Community
+permissions:
+  - shell_exec
+---
+
+# SQL Executor
+
+Write and run SQL for PostgreSQL databases, including Supabase projects that expose a Postgres connection string.
+
+Before execution, read [the command reference](references/commands.md).
+
+## Goals
+
+- turn plain-English requests into correct SQL
+- inspect schema before guessing table or column names
+- execute read-only queries with clear result summaries
+- require confirmation before any mutation or schema change
+- keep database credentials out of the conversation transcript
+- avoid fragile shell quoting when sending generated SQL to `psql`
+
+## Setup
+
+1. Find a connection target from one of these environment variables:
+   - `DATABASE_URL`
+   - `POSTGRES_URL`
+   - `POSTGRES_URL_NON_POOLING`
+   - `SUPABASE_DB_URL`
+   - `SUPABASE_DATABASE_URL`
+2. If multiple supported variables exist, ask which variable name to use. Do not print their values.
+3. If no supported variable exists, stop and ask the user to set one in their local environment or configure the connection through the host's local secret/config mechanism. Do not ask the user to paste a database URL or password into chat.
+4. Prefer `psql` for execution.
+5. If the Supabase CLI is installed and the user is working locally, `supabase status` may be used to confirm the local stack.
+
+## Workflow
+
+1. **Understand the request.** Decide whether the user wants schema discovery, a read query, a data fix, or a schema change.
+2. **Inspect first when needed.** If table or column names are not certain, query `information_schema` before writing the final SQL.
+3. **Draft the SQL.** Keep it minimal and explicit. Avoid `select *` unless the user asks for it.
+4. **Classify risk.**
+   - Read path: `select`, metadata queries, and non-ANALYZE `explain` statements that can run under a database-enforced read-only guard
+   - Mutation path: `insert`, `update`, `delete`, `alter`, `drop`, `truncate`, `create`, `grant`, `revoke`, side-effecting functions, data-modifying CTEs, and `explain analyze`
+5. **Execute safely.**
+   - Unconfirmed reads may run only inside a database-enforced read-only transaction/session.
+   - Any query that fails under the read-only guard because it attempted a write or side effect must be rerouted through the mutation-confirmation flow. Do not retry it outside the guard without confirmation.
+   - Mutating queries must be shown to the user first with a short impact summary, then executed only after confirmation.
+6. **Verify the outcome.** After a mutation, run a small follow-up query when practical.
+7. **Report clearly.** Share the SQL and a concise summary of the result. Do not reveal credential values.
+
+## Execution Rules
+
+### 1) Connection handling
+- Use only a database URL that is already available through an environment variable or host-provided local secret/config mechanism.
+- Never ask the user to paste a full database URL, database password, or other credential into the conversation.
+- Never print full secrets back to the user.
+- If multiple database URL variables are present, ask the user to choose by variable name only.
+- If the user accidentally shares a credential in chat, do not use it. Tell them to rotate it and set the replacement outside the conversation.
+
+### 2) Command style
+Use strict `psql` execution with error stopping and paging disabled. Pass generated SQL through stdin with a single-quoted heredoc delimiter. For unconfirmed reads, always combine this with the read-only transaction pattern below.
+
+Do not interpolate generated SQL into an inline shell command. SQL often contains quotes, semicolons, dollar-quoted strings, or user-provided literal values, and shell quoting mistakes can change what reaches Postgres.
+
+When using a heredoc:
+- choose a delimiter that does not appear in the SQL body
+- keep the delimiter single-quoted so the shell does not expand SQL text
+- keep credentials in environment variables, not in the command text
+
+### 3) Unconfirmed read execution
+Unconfirmed reads must fail closed at the database boundary. Run every unconfirmed read, metadata inspection, and schema discovery query inside a read-only transaction/session:
+
+```bash
+psql "$DATABASE_URL" -X -v ON_ERROR_STOP=1 -P pager=off <<'__ZEROCLAW_SQL__'
+BEGIN READ ONLY;
+SET LOCAL statement_timeout = '30s';
+
+select now();
+
+COMMIT;
+__ZEROCLAW_SQL__
+```
+
+Rules for unconfirmed reads:
+- Put the generated read SQL between `SET LOCAL` and `COMMIT`.
+- Do not include generated transaction-control statements such as `begin`, `commit`, `rollback`, `savepoint`, or `set transaction` in the user SQL body.
+- If the read-only guard rejects the statement, stop and route the request through mutation confirmation.
+- Treat data-modifying CTEs and side-effecting functions as mutation-path requests, even if the SQL starts with `select`.
+- `EXPLAIN ANALYZE` executes the target statement and is not automatically read-only. Run it only under the read-only guard when appropriate, or require explicit mutation confirmation.
+
+### 4) Read query defaults
+- Add `limit 100` for exploratory result sets unless the user asks otherwise.
+- Prefer explicit column lists.
+- Add `order by` when recency or ranking matters.
+- Use aggregates for counts and summaries instead of dumping huge tables.
+
+### 5) Mutation safety
+Before any mutating SQL:
+- show the exact SQL
+- explain which rows or objects are affected
+- mention whether the action is reversible
+- ask for confirmation
+
+After confirmation:
+- execute the SQL through stdin/heredoc, not inline shell quoting
+- use an explicit transaction for multi-step changes when practical
+- capture the affected row count or command result
+- run a verification query when useful, using the read-only guard for verification reads
+
+### 6) Supabase specifics
+- Treat Supabase as PostgreSQL for SQL execution.
+- If the user says “Supabase” but no connection variable is configured, ask them to set one of the supported environment variables from their Supabase project's Postgres connection settings. Do not ask them to paste the connection string in chat.
+- For local Supabase, the common default target can be placed in an environment variable such as `SUPABASE_DB_URL`.
+
+## Output format
+
+Use this structure:
+
+```text
+Target: [environment variable name or local target label]
+Mode: [read-only or mutating]
+SQL:
+[query]
+
+Result:
+[short summary]
+```
+
+For mutating queries awaiting approval, use:
+
+```text
+Target: [environment variable name or local target label]
+Mode: mutating
+Impact: [what will change]
+SQL:
+[query]
+
+Awaiting confirmation.
+```
+
+## Rules
+
+- Never invent table or column names when schema inspection is possible.
+- Never run mutating SQL without confirmation.
+- Never ask users to paste credentials into chat.
+- Never expose full credentials in the response.
+- Never embed generated SQL inside a shell-quoted inline `psql` command.
+- Never run an unconfirmed read outside a database-enforced read-only transaction/session.
+- If a query fails, show the relevant error and propose a corrected query.
+- Prefer transactional thinking for risky multi-step changes.
+- When the request is ambiguous, ask one focused question instead of guessing.

--- a/skills/sql-executor/references/commands.md
+++ b/skills/sql-executor/references/commands.md
@@ -1,0 +1,112 @@
+# sql-executor command reference
+
+## Preferred execution model
+
+Use `psql` with strict error handling and no pager. Pass SQL through stdin with a single-quoted heredoc delimiter. Do not put generated SQL inside inline shell command arguments. Generated SQL can contain quotes, semicolons, dollar-quoted strings, and user-provided literal values.
+
+Keep SQL text in stdin and keep credentials in environment variables.
+
+## Unconfirmed read execution
+
+Unconfirmed reads must run under a database-enforced read-only guard. Use this pattern for reads, schema discovery, metadata inspection, and other unconfirmed SQL:
+
+```bash
+psql "$DATABASE_URL" -X -v ON_ERROR_STOP=1 -P pager=off <<'__ZEROCLAW_SQL__'
+BEGIN READ ONLY;
+SET LOCAL statement_timeout = '30s';
+
+select now();
+
+COMMIT;
+__ZEROCLAW_SQL__
+```
+
+Rules:
+
+1. Put generated read SQL between `SET LOCAL` and `COMMIT`.
+2. Do not include generated transaction-control statements such as `begin`, `commit`, `rollback`, `savepoint`, or `set transaction` in the SQL body.
+3. If the read-only transaction rejects the statement, stop. Do not retry outside the guard without explicit mutation confirmation.
+4. Treat data-modifying CTEs and side-effecting functions as mutation-path requests even if the statement starts with `select`.
+5. `EXPLAIN ANALYZE` executes the target statement and is not automatically read-only. Run it only under the read-only guard when appropriate, or require explicit mutation confirmation.
+
+## Confirmed mutation execution
+
+After explicit user confirmation, execute mutations through stdin/heredoc as well. Use an explicit transaction for multi-step changes when practical:
+
+```bash
+psql "$DATABASE_URL" -X -v ON_ERROR_STOP=1 -P pager=off <<'__ZEROCLAW_SQL__'
+BEGIN;
+
+-- confirmed mutating SQL here
+
+COMMIT;
+__ZEROCLAW_SQL__
+```
+
+After the mutation, run verification reads under the unconfirmed read execution pattern.
+
+## Heredoc safety
+
+When using a heredoc:
+
+1. Use a delimiter that does not appear in the SQL body.
+2. Single-quote the delimiter so the shell does not expand SQL text.
+3. Do not echo or print the database URL.
+
+## Common environment variables
+
+Check these supported variables without printing their values:
+
+1. `DATABASE_URL`
+2. `POSTGRES_URL`
+3. `POSTGRES_URL_NON_POOLING`
+4. `SUPABASE_DB_URL`
+5. `SUPABASE_DATABASE_URL`
+
+Target-selection rule:
+
+- If exactly one supported variable exists, use that variable name.
+- If more than one supported variable exists, ask the user to choose by variable name only. Do not print or expose any values.
+- If none exist, ask the user to set one locally or configure a connection through the host's local secret/config mechanism. Do not ask the user to paste a database URL or password into chat.
+
+## Schema discovery
+
+Run schema discovery under the unconfirmed read execution pattern.
+
+```sql
+select table_schema, table_name
+from information_schema.tables
+where table_schema not in ('pg_catalog', 'information_schema')
+order by table_schema, table_name;
+```
+
+```sql
+select table_schema, table_name, column_name, data_type, is_nullable
+from information_schema.columns
+where table_schema not in ('pg_catalog', 'information_schema')
+order by table_schema, table_name, ordinal_position;
+```
+
+## Size limits
+
+For exploration queries, default to `limit 100` unless the user asks for full output or aggregates.
+
+## Mutation policy
+
+For `insert`, `update`, `delete`, `alter`, `drop`, `truncate`, `create`, `grant`, `revoke`, data-modifying CTEs, side-effecting functions, or unguarded `EXPLAIN ANALYZE`:
+
+1. Draft the SQL.
+2. Explain the impact.
+3. Ask for confirmation.
+4. Execute only after confirmation.
+5. Run a verification query under the read-only guard when practical.
+
+## Supabase notes
+
+- Supabase uses PostgreSQL, so `psql` works with the database connection string from the Supabase dashboard when that string is stored outside the conversation.
+- Ask users to set a supported environment variable from their local terminal or host secret/config mechanism.
+- If the Supabase CLI is installed, you can inspect local status with:
+
+```bash
+supabase status
+```


### PR DESCRIPTION
Adds a new community skill, sql-executor, to the ZeroClaw skills registry. The skill lets ZeroClaw translate natural-language requests into PostgreSQL or Supabase SQL, inspect schemas when needed, run read-only queries, and require explicit confirmation before mutating operations like insert, update, delete, alter, drop, or truncate. The skill uses `psql` through `shell_exec`, supports common Postgres/Supabase connection environment variables, treats Supabase as PostgreSQL, documents local Supabase defaults, and applies conservative defaults such as schema inspection and `limit 100` for exploratory queries.