### PR TITLE
fix: harmonize git-assistant and code-reviewer manifest descriptions

### DIFF
--- a/skills/code-reviewer/manifest.toml
+++ b/skills/code-reviewer/manifest.toml
@@ -2,7 +2,7 @@
 name = "code-reviewer"
 version = "0.2.0"
 author = "zeroclaw-labs"
-description = "AI-powered code review. Catches bugs, suggests improvements, checks style."
+description = "AI-powered code review. Catches bugs, suggests improvements, checks style. Analyzes code changes, diffs, or pull requests and provides actionable, prioritized feedback. Use when the user wants a code review, wants to check code quality, or needs feedback on a diff or PR."
 category = "coding"
 tags = ["Official"]
 license = "MIT"

--- a/skills/git-assistant/manifest.toml
+++ b/skills/git-assistant/manifest.toml
@@ -2,7 +2,7 @@
 name = "git-assistant"
 version = "0.2.0"
 author = "zeroclaw-labs"
-description = "Smart git operations — interactive rebase, conflict resolution, changelog generation."
+description = "Smart git operations — interactive rebase, conflict resolution, changelog generation. Helps users perform git workflows safely and efficiently, from everyday operations to complex history manipulation. Use when the user needs help with git commands, merge conflicts, rebasing, or changelog generation."
 category = "tools"
 tags = ["Official"]
 license = "MIT"


### PR DESCRIPTION
## Summary
- Two skills (`git-assistant`, `code-reviewer`) were missed by the original harmonization in #7 and still had shorter `manifest.toml` descriptions than their `SKILL.md` frontmatter, causing the runtime to emit description-mismatch WARNs at load and fall back to the abbreviated TOML text for tool selection.
- Inlines each `SKILL.md` description into `manifest.toml` (single-line, since TOML lacks YAML block-folding). No behavioral or permission changes.

## Test plan
- [ ] Reload the registry locally and confirm the two `description mismatch between TOML and SKILL.md` warnings for `git-assistant` and `code-reviewer` are gone.
- [ ] Grep remaining `manifest.toml` files to confirm no other skills still have a shorter TOML description than their SKILL.md frontmatter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)